### PR TITLE
Add preference for showing the copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Just add `#{prefix_highlight}` to your left/right status bar.
 set -g status-right '#{prefix_highlight} | %a %Y-%m-%d %H:%M'
 ```
 
+The plugin can also be configured to show when copy mode is active; see the
+**Configurations** section for details.
+
 ### Installation with Tmux Plugin Manager (recommended)
 
 Add plugin to the list of TPM plugins:
@@ -52,9 +55,21 @@ $ tmux source-file ~/.tmux.conf
 
 ### Configurations
 
+The colors used for the prefix highlight can be configured:
+
 ```tmux.conf
-set -g @prefix_highlight_fg 'white'
-set -g @prefix_highlight_bg 'blue'
+set -g @prefix_highlight_fg 'white' # default is 'colour231'
+set -g @prefix_highlight_bg 'blue'  # default is 'colour04'
+```
+
+The plugin can also be configured to show when copy mode is active. If enabled,
+the `#{prefix_highlight}` token will be replaced with the string `Copy` when
+copy mode is enabled. The style for copy mode can be configured as a
+comma-separated list of colors and attributes:
+
+```tmux.conf
+set -g @prefix_highlight_show_copy_mode 'on'
+set -g @prefix_highlight_copy_mode_attr 'fg=black,bg=yellow,bold' # default is 'fg=default,bg=yellow'
 ```
 
 ### License

--- a/prefix_highlight.tmux
+++ b/prefix_highlight.tmux
@@ -8,10 +8,17 @@ place_holder="\#{prefix_highlight}"
 # Possible configurations
 fg_color_config='@prefix_highlight_fg'
 bg_color_config='@prefix_highlight_bg'
+show_copy_config='@prefix_highlight_show_copy_mode'
+copy_attr_config='@prefix_highlight_copy_mode_attr'
 
 # Defaults
 default_fg='colour231'
 default_bg='colour04'
+default_copy_attr='fg=default,bg=yellow'
+
+# internal variables
+prefix_attr_var='@_prefix_highlight_attr_prefix'
+copy_attr_var='@_prefix_highlight_attr_copy'
 
 tmux_option() {
     local -r value=$(tmux show-option -gqv "$1")
@@ -25,9 +32,14 @@ tmux_option() {
 }
 
 highlight() {
-    local -r status="$1" prefix="$2" fg_color="$3" bg_color="$4"
+    local -r status="$1" prefix="$2" show_copy_mode="$3"
     local -r status_value=$(tmux_option "$status")
-    local -r highlight_on_prefix="#[fg=$fg_color,bg=$bg_color]#{?client_prefix, $prefix ,}#[fg=default,bg=default]"
+    if [[ "on" = "$show_copy_mode" ]]; then
+        local -r fallback="#{?pane_in_mode,#{$copy_attr_var}Copy,}"
+    else
+        local -r fallback=""
+    fi
+    local -r highlight_on_prefix="#{?client_prefix,#{$prefix_attr_var} $prefix ,$fallback}#[default]"
 
     tmux set-option -gq "$status" "${status_value/$place_holder/$highlight_on_prefix}"
 }
@@ -36,14 +48,20 @@ main() {
     local -r \
         prefix=$(tmux_option prefix) \
         fg_color=$(tmux_option "$fg_color_config" "$default_fg") \
-        bg_color=$(tmux_option "$bg_color_config" "$default_bg")
+        bg_color=$(tmux_option "$bg_color_config" "$default_bg") \
+        show_copy_mode=$(tmux_option "$show_copy_config") \
+        copy_attr=$(tmux_option "$copy_attr_config" "$default_copy_attr")
 
     local -r short_prefix=$(
         echo "$prefix" | tr "[:lower:]" "[:upper:]" | sed 's/C-/\^/'
     )
 
-    highlight "status-right" "$short_prefix" "$fg_color" "$bg_color"
-    highlight "status-left" "$short_prefix" "$fg_color" "$bg_color"
+    # set internal variables
+    tmux set-option -gq "$prefix_attr_var" "#[fg=$fg_color,bg=$bg_color]" \; \
+        set-option -gq "$copy_attr_var" "${copy_attr:+#[default,$copy_attr]}"
+
+    highlight "status-right" "$short_prefix" "$show_copy_mode"
+    highlight "status-left" "$short_prefix" "$show_copy_mode"
 }
 
 main


### PR DESCRIPTION
If the variable `@prefix_highlight_show_copy_mode` is set to `"on"`, the
`#{prefix_highlight}` placeholder will be replaced with the string
`Copy` whenever copy mode is enabled. The prefix highlight takes
precedence over showing copy mode. The attributes for copy mode can be
controlled by the `@prefix_highlight_copy_mode_attr` variable, which
should be a comma-separated list of attributes, with the default value
of `fg=default,bg=yellow`.

At the end of the token, use `#[default]` instead of
`#[fg=default,bg=default]`. This is done because the copy mode may
include arbitrary attributes, and also to make it easier in the future
to change the prefix highlight config to use arbitrary attributes too.