### PR TITLE
Add plugin_interpolated_options support

### DIFF
--- a/prefix_highlight.tmux
+++ b/prefix_highlight.tmux
@@ -94,11 +94,12 @@ main() {
 
     local -r highlight="#{?client_prefix,$prefix_mode,$fallback}#[default]"
 
-    local -r status_left_value="$(tmux_option "status-left")"
-    tmux set-option -gq "status-left" "${status_left_value/$place_holder/$highlight}"
-
-    local -r status_right_value="$(tmux_option "status-right")"
-    tmux set-option -gq "status-right" "${status_right_value/$place_holder/$highlight}"
+    local interpolated_options="$(tmux_option "@plugin_interpolated_options" "status-right status-left")"
+    for interpolated_option in $interpolated_options
+    do
+        local -r option_value="$(tmux_option $interpolated_option)"
+        tmux set-option -gq $interpolated_option "${option_value/$place_holder/$highlight}"
+    done
 }
 
 main


### PR DESCRIPTION
When using a multi-line status-format, having the interpolation restricted to status_left and status_right is problematic.

This adds an option to configure which options are interpolated by the plugin. Because there are multiple plugins using the same interpolation technique, and they are all subject to the same restrictions, I used "@plugin_interpolated_options" as the option name. That option could be reused by other plugins for the same purpose.

If the option is not found, it defaults to "status-right status-left", the current behavior.


To support multi-line status-format, the status line to interpolate can be added to @plugin_interpolated_options in ~/.tmux.conf:

`set -g @plugin_interpolated_options 'status-format[0] status-left status-right'`


This option also allows a very small improvement in startup performance by only interpolating the necessary options. For example, to only interpolate status-right:

`set -g @plugin_interpolated_options 'status-right'`