### PR TITLE
PoC: add support for all known pane modes

### DIFF
--- a/prefix_highlight.tmux
+++ b/prefix_highlight.tmux
@@ -67,8 +67,18 @@ main() {
     local -r prefix_highlight="$(format_style "fg=$fg_color,bg=$bg_color")"
     local -r prefix_mode="$prefix_highlight$output_prefix$prefix_prompt$output_suffix"
 
+    # add support for all (known) pane modes
+    local -r pane_mode="#{s/-mode//:#{pane_mode}}"
+    local -r clock_mode_sub="#{#{?#{==:$pane_mode,clock},clck,#{pane_mode} is not yet supported; please report}}"
+    local -r options_mode_sub="#{#{?#{==:$pane_mode,options},opts,$clock_mode_sub}}"
+    local -r client_mode_sub="#{#{?#{==:$pane_mode,client},Clnt,$options_mode_sub}}"
+    local -r buffer_mode_sub="#{#{?#{==:$pane_mode,buffer},Bufr,$client_mode_sub}}"
+    local -r tree_mode_sub="#{#{?#{==:$pane_mode,tree},Tree,$buffer_mode_sub}}"
+    local -r view_mode_sub="#{#{?#{==:$pane_mode,view},View,$tree_mode_sub}}"
+    local -r copy_mode_sub="#{#{?#{==:$pane_mode,copy},Copy,$view_mode_sub}}"
+
     local -r copy_highlight="$(format_style "${copy_attr:+default,$copy_attr}")"
-    local -r copy_mode="$copy_highlight$output_prefix$copy_prompt$output_suffix"
+    local -r copy_mode="$copy_highlight$output_prefix$copy_mode_sub$output_suffix"
 
     local -r sync_highlight="$(format_style "${sync_attr:+default,$sync_attr}")"
     local -r sync_mode="$sync_highlight$output_prefix$sync_prompt$output_suffix"


### PR DESCRIPTION
Hi @erickpintor, I want to bring to your attention that the way the pane-modes are currently displayed is incorrect. The error occurs on [this line](https://github.com/tmux-plugins/tmux-prefix-highlight/blob/13a16701207f3aac846cf7daed3f45ed3e7ea756/prefix_highlight.tmux#L87) (and the related line 2 lines above), where it's assumed that if a pane is in a mode, it's necessarily in copy mode.

I'm not sure if it was the case that tmux only had copy mode back in 2015 when this plugin was first created, but in its present version, it now contains a number of different pane modes. The ones that I've been able to identify besides copy mode are:

- view-mode (`list-keys` command, or the default `prefix + ?` keybind)
- tree-mode (`choose-tree` command, or the default `prefix + s` and `prefix + w` keybinds)
- client-mode (`choose-client` command, or the default `prefix + D` keybind)
- buffer-mode (`choose-buffer` command, or the default `prefix + =` keybind)
- options-mode (`customize-mode` command)
- clock-mode (`clock-mode` command, or the default `prefix + t` keybind)

This PR contains a quick and dirty patch I did to add support for these additional pane modes. And you can see some examples below:

View mode:
<img width="1440" alt="image" src="https://github.com/tmux-plugins/tmux-prefix-highlight/assets/12605746/7cac419f-d248-4764-9a66-a4597030e798">

Copy mode:
<img width="1440" alt="image" src="https://github.com/tmux-plugins/tmux-prefix-highlight/assets/12605746/ce946de8-15fa-43e4-89f7-dc7ae0b3c4da">

Buffer mode:
<img width="1440" alt="image" src="https://github.com/tmux-plugins/tmux-prefix-highlight/assets/12605746/93f80511-f460-4f2c-a205-77e7c0a4509b">


At this point, I just want to bring this to your attention as I already mentioned, and I do not intend this to be the final version that gets merged, should you agree that this is indeed in need of fixing. And if that's indeed the case, here are some implementation details that would need to be addressed:

- variable names in the script should be updated to reflect their new purposes, e.g. instead of `copy_mode`, probably something like `pane_mode` is more apt
- add user configurable prompt texts, e.g. `prefix_highlight_tree_prompt` and `prefix_highlight_options_prompt`, which are currently hardcoded as `Tree` and `Opts` respectively
- possibly rethink the entire mechanism for implementing the different pane modes' prompts; as you can see, they're currently done using nested tmux formatting conditionals, which is ugly and clunky to say the least; perhaps an external script is needed; your input on how best to achieve this is definitely welcome